### PR TITLE
Replaced `Expr::valid()` calls with `Expr::true()`

### DIFF
--- a/src/Asset/DiscoveryAssetManager.php
+++ b/src/Asset/DiscoveryAssetManager.php
@@ -20,7 +20,6 @@ use Puli\AssetPlugin\Api\Target\InstallTargetCollection;
 use Puli\AssetPlugin\Api\Target\NoSuchTargetException;
 use Puli\Manager\Api\Discovery\BindingDescriptor;
 use Puli\Manager\Api\Discovery\DiscoveryManager;
-use Puli\Manager\Api\Package\RootPackage;
 use Rhumsaa\Uuid\Uuid;
 use Webmozart\Expression\Expr;
 use Webmozart\Expression\Expression;
@@ -127,7 +126,7 @@ class DiscoveryAssetManager implements AssetManager
      */
     public function getRootAssetMappings()
     {
-        return $this->findRootAssetMappings(Expr::valid());
+        return $this->findRootAssetMappings(Expr::true());
     }
 
     /**
@@ -183,7 +182,7 @@ class DiscoveryAssetManager implements AssetManager
      */
     public function getAssetMappings()
     {
-        return $this->findAssetMappings(Expr::valid());
+        return $this->findAssetMappings(Expr::true());
     }
 
     /**

--- a/src/Installer/PackageFileInstallerManager.php
+++ b/src/Installer/PackageFileInstallerManager.php
@@ -176,7 +176,7 @@ class PackageFileInstallerManager implements InstallerManager
      */
     public function clearRootInstallerDescriptors()
     {
-        $this->removeRootInstallerDescriptors(Expr::valid());
+        $this->removeRootInstallerDescriptors(Expr::true());
     }
 
     /**

--- a/src/Target/PackageFileInstallTargetManager.php
+++ b/src/Target/PackageFileInstallTargetManager.php
@@ -132,7 +132,7 @@ class PackageFileInstallTargetManager implements InstallTargetManager
      */
     public function clearTargets()
     {
-        $this->removeTargets(Expr::valid());
+        $this->removeTargets(Expr::true());
     }
 
     /**


### PR DESCRIPTION
The plugin is broken since [this change](https://github.com/webmozart/expression/commit/af7f2f175b86e58c0baacc937b6b562e95194152) in Expression.
